### PR TITLE
Include the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README
+include LICENSE
 include setup.py
 recursive-include importlib *.py


### PR DESCRIPTION
Ensure the license file is included in `sdist`s and related packages.
